### PR TITLE
various changes to the GCP terraform config:

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -4,7 +4,7 @@
 
 1. Create a project in GCP and enable Google Kubernetes Engine (GKE) for the project.
 2. Install [`gcloud`](https://cloud.google.com/sdk/docs/install) and [`terraform`](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) on your local machine.
-3. GCP credentials will allow you to perform administrative actions using IaC tooling. To create them:
+3. [OPTIONAL] Create a service account. If you choose not to, terraform will provision one for you during the `apply` step. To create your own follow the steps below:
 
 > - Go to the [create service account](https://console.cloud.google.com/apis/credentials/serviceaccountkey) key page
 > - Select the default service account or create a new one

--- a/gcp/terraform.tfvars
+++ b/gcp/terraform.tfvars
@@ -1,18 +1,20 @@
+### Detailed descriptions of each variable can be found in variables.tf ###
+
 ### GCP Variables ###
 # project_id = "default-project-id"
-# region = "us-east1"
+# region = "us-central1"
+# zones = ["us-central1-a"]
 
 ### Deployment Variables ###
-# deployment_name = "terraform-gke-testing"
-# sourcegraph_version = "4.0.1"
-# ssl_domains = []
+# deployment_name = "sourcegraph-cluster"
 
 ### Node Pool Variables ###
+## OPTIONAL - add your own service account ##
 # service_account = "project-service-account"
-# instance_type = "n2d-highcpu-16"
+# instance_type = "n1-standard-32"
 # node_min_count = 0
-# node_max_count = 10
-# node_desired_count = 1
+# node_max_count = 4
+# node_desired_count = 2
 
 ### Autoscaling Variables ###
 # min_cpu_cores = 1

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -12,8 +12,14 @@ variable "deployment_name" {
 
 variable "region" {
   type        = string
-  default     = "us-east1"
+  default     = "us-central1"
   description = "region to deploy cluster to"
+}
+
+variable "zones" {
+  type        = list(string)
+  default     = ["us-central1-a"]
+  description = "zones to deploy cluster to"
 }
 
 ### Autoscaling variables ###


### PR DESCRIPTION
- Remove second subnet
- Mark `service account` as optional for user
- Add taints which are necessary for auto-scaling
- Change default values in `.tfvars` file