### PR TITLE
Adjusts default variables for GCP config

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -26,3 +26,8 @@ From inside the cloned directory:
 3. Run `terraform apply`. This will deploy the cluster to the specified GCP project. Type 'yes' at the prompt.
 
 Congrats. You have a Kubernetes cluster. Next, [it's time to deploy Sourcegraph](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure).
+
+### Managing Your Cluster with Kubectl
+To pull logs and manage your cluster, you can use the `kubectl` [cli tool](https://kubernetes.io/docs/tasks/tools/), which you'll need to configure cluster access for with [`gcloud`](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl). You can do so with the following command:
+
+`gcloud container clusters --region=$REGION get-credentials $CLUSTER_NAME`

--- a/gcp/terraform.tfvars
+++ b/gcp/terraform.tfvars
@@ -13,7 +13,7 @@
 # service_account = "project-service-account"
 # instance_type = "n1-standard-32"
 # node_min_count = 0
-# node_max_count = 4
+# node_max_count = 2
 # node_desired_count = 2
 
 ### Autoscaling Variables ###

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -25,13 +25,13 @@ variable "zones" {
 ### Autoscaling variables ###
 variable "min_cpu_cores" {
   type        = number
-  default     = 0
+  default     = 1
   description = "Minimum total CPU cores for auto-scaling nodes"
 }
 
 variable "min_memory_gb" {
   type        = number
-  default     = 0
+  default     = 1
   description = "Minimum total GB of memory for auto-scaling nodes"
 }
 
@@ -56,19 +56,19 @@ variable "gpu_resources" {
 ### Node pool variables ###
 variable "instance_type" {
   type        = string
-  default     = "e2-medium"
+  default     = "n1-standard-32"
   description = "The instance type for the nodes in the cluster"
 }
 
 variable "node_min_count" {
   type        = number
-  default     = 1
+  default     = 0
   description = "Minimum number of nodes to be available in the node pool"
 }
 
 variable "node_max_count" {
   type        = number
-  default     = 100
+  default     = 2
   description = "Maximum number of nodes to be available in the node pool"
 }
 
@@ -80,6 +80,6 @@ variable "service_account" {
 
 variable "node_desired_count" {
   type        = number
-  default     = 1
+  default     = 2
   description = "Desired number of nodes to be available in the node pool"
 }


### PR DESCRIPTION
- A few variables had values that were either too high or too low for a default cluster.
- This commit adjusts those variables accordingly, and makes sure that the defaults of all variables match the initial values for the corresponding keys in terraform.tfvars