### PR TITLE
aws: update vpc module version

### DIFF
--- a/aws/add-ons.tf
+++ b/aws/add-ons.tf
@@ -1,6 +1,7 @@
 resource "aws_eks_addon" "addons" {
   cluster_name             = module.eks.cluster_id
   addon_name               = "aws-ebs-csi-driver"
-  resolve_conflicts        = "OVERWRITE"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
   service_account_role_arn = aws_iam_role.ebs-csi-role.arn
 }

--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.2"
+  version = "5.1.2"
 
   name = "${var.deployment_name}-replica-env-vpc"
 


### PR DESCRIPTION
Address `terraform plan` failure and deprecations in `eks_addon` as well as AWS `vpc` module.